### PR TITLE
Fix: Correct Camera2D spawning to resolve Clippy error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,5 +9,5 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn(Camera2d::default());
+    commands.spawn(Camera2dBundle::default());
 }


### PR DESCRIPTION
This PR fixes the Clippy error `default_constructed_unit_structs` in `src/main.rs` by using `Camera2dBundle::default()` instead of `Camera2d::default()` for spawning the 2D camera. This aligns with Bevy Engine's standard practices and should resolve the build failures in GitHub Actions.

Closes #4