### PR TITLE
feat: Implement 'info city' command and basic command loop

### DIFF
--- a/src/game_state.py
+++ b/src/game_state.py
@@ -56,7 +56,7 @@ class GameState:
         city = self.game_map.get_city(city_id)
         if unit and city:
             unit.current_location_city_id = city_id
-            if unit_id not in city.garrisoned_units:
+            if unit_id not in city.garrisoned_units: # Ensure garrison list exists
                 city.garrisoned_units.append(unit_id)
 
 
@@ -64,7 +64,9 @@ class GameState:
         print(f"--- Game State: Turn {self.current_turn} ---")
         print(f"Map: {self.game_map.map_id} with {len(self.game_map.cities)} cities.")
         if self.player_faction_id:
-            print(f"Player is controlling: {self.factions.get(self.player_faction_id).name}")
+            player_faction = self.factions.get(self.player_faction_id)
+            if player_faction:
+                 print(f"Player is controlling: {player_faction.name}")
 
         print("\nFactions:")
         for faction_id, faction_obj in self.factions.items():
@@ -95,6 +97,38 @@ class GameState:
             if unit_obj.owning_faction_id and unit_obj.owning_faction_id in self.factions:
                 faction_name = self.factions[unit_obj.owning_faction_id].short_name
             print(f"- Unit {unit_id} ({unit_obj.unit_type_id}), Faction: {faction_name}, Location: {unit_obj.current_location_city_id or 'Field'}, Soldiers: {unit_obj.soldiers}")
+
+    def get_city_details_str(self, city_id: str) -> str:
+        city = self.game_map.get_city(city_id)
+        if not city:
+            return f"Error: City with ID '{city_id}' not found."
+
+        details = [f"--- City Details: {city.name} (ID: {city_id}) ---"]
+        details.append(f"Region: {city.region_id}")
+        owner_name = "Unowned"
+        if city.current_owner_faction_id:
+            faction = self.factions.get(city.current_owner_faction_id)
+            if faction:
+                owner_name = f"{faction.name} (ID: {faction.faction_id})"
+        details.append(f"Owner: {owner_name}")
+        details.append(f"Population: {city.population}")
+        details.append(f"Economy: {city.economy}")
+        details.append(f"Industry: {city.industry}")
+        
+        garrison_str = "None"
+        if city.garrisoned_units:
+            garrison_details = []
+            for unit_id in city.garrisoned_units:
+                unit = self.army_units.get(unit_id)
+                if unit:
+                    garrison_details.append(f"  - {unit.unit_id} ({unit.unit_type_id}, {unit.soldiers} soldiers)")
+                else:
+                    garrison_details.append(f"  - {unit_id} (Error: Unit details not found)")
+            if garrison_details:
+                 garrison_str = "\n" + "\n".join(garrison_details)
+        details.append(f"Garrison: {garrison_str}")
+        
+        return "\n".join(details)
 
     def next_turn(self):
         self.current_turn += 1

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,4 @@
 '''
-# Using type hints for clarity, actual imports will be relative for package structure
-# from game_enums import TerrainType
 from faction import Faction
 from city import City
 from general import General
@@ -16,7 +14,7 @@ def setup_initial_state() -> GameState:
     paris = City(city_id="paris", name="Paris", region_id="ile_de_france")
     london = City(city_id="london", name="London", region_id="greater_london")
     vienna = City(city_id="vienna", name="Vienna", region_id="austria_proper")
-    berlin = City(city_id="berlin", name="Berlin", region_id="brandenburg")
+    berlin = City(city_id="berlin", name="Berlin", region_id="brandenburg") # Expanded
 
     europe_map.add_city(paris)
     europe_map.add_city(london)
@@ -30,70 +28,99 @@ def setup_initial_state() -> GameState:
     france = Faction(faction_id="france", name="French Empire", short_name="France", capital_city_id="paris")
     britain = Faction(faction_id="britain", name="Great Britain", short_name="Britain", capital_city_id="london")
     austria = Faction(faction_id="austria", name="Austrian Empire", short_name="Austria", capital_city_id="vienna")
+    prussia = Faction(faction_id="prussia", name="Kingdom of Prussia", short_name="Prussia", capital_city_id="berlin") # Expanded
 
     game.add_faction(france)
     game.add_faction(britain)
     game.add_faction(austria)
-    game.player_faction_id = "france" # Set player faction
+    game.add_faction(prussia) # Expanded
+    game.player_faction_id = "france"
 
     # 5. Assign cities to factions
     game.assign_city_to_faction("paris", "france")
     game.assign_city_to_faction("london", "britain")
     game.assign_city_to_faction("vienna", "austria")
-    # Berlin is initially unowned or could belong to Prussia (not yet created)
+    game.assign_city_to_faction("berlin", "prussia") # Expanded
 
     # 6. Create Generals and add to game state
     napoleon = General(general_id="napoleon", name="Napoleon Bonaparte", faction_id="france", command=95, attack_skill=90, defense_skill=80)
     davout = General(general_id="davout", name="Louis Davout", faction_id="france", command=85, attack_skill=80, defense_skill=75)
-    nelson = General(general_id="nelson", name="Horatio Nelson", faction_id="britain", command=90) # Example, Nelson mostly naval
+    nelson = General(general_id="nelson", name="Horatio Nelson", faction_id="britain", command=90)
     archduke_charles = General(general_id="archduke_charles", name="Archduke Charles", faction_id="austria", command=80)
+    blucher = General(general_id="blucher", name="Gebhard von Blucher", faction_id="prussia", command=82) # Expanded
 
     game.add_general(napoleon)
     game.add_general(davout)
     game.add_general(nelson)
     game.add_general(archduke_charles)
+    game.add_general(blucher) # Expanded
 
     # 7. Place Generals in cities
     game.place_general_in_city("napoleon", "paris")
-    game.place_general_in_city("davout", "paris") # For simplicity, can be moved later
+    game.place_general_in_city("davout", "paris")
     game.place_general_in_city("nelson", "london")
     game.place_general_in_city("archduke_charles", "vienna")
+    game.place_general_in_city("blucher", "berlin") # Expanded
 
 
     # 8. Create Army Units and add to game state
-    grande_armee_1st_corps = ArmyUnit(unit_id="fra_corps_1", unit_type_id="infantry_corps", owning_faction_id="france", soldiers=25000, leading_general_id="davout")
-    royal_navy_channel_fleet = ArmyUnit(unit_id="bri_fleet_1", unit_type_id="fleet_channel", owning_faction_id="britain", soldiers=100) # soldiers as ship count?
-    austrian_main_army = ArmyUnit(unit_id="aus_army_1", unit_type_id="infantry_division", owning_faction_id="austria", soldiers=30000, leading_general_id="archduke_charles")
+    fra_corps_1 = ArmyUnit(unit_id="fra_corps_1", unit_type_id="infantry_corps", owning_faction_id="france", soldiers=25000, leading_general_id="davout")
+    bri_fleet_1 = ArmyUnit(unit_id="bri_fleet_1", unit_type_id="fleet_channel", owning_faction_id="britain", soldiers=100) 
+    aus_army_1 = ArmyUnit(unit_id="aus_army_1", unit_type_id="infantry_division", owning_faction_id="austria", soldiers=30000, leading_general_id="archduke_charles")
+    pru_corps_1 = ArmyUnit(unit_id="pru_corps_1", unit_type_id="infantry_corps", owning_faction_id="prussia", soldiers=22000, leading_general_id="blucher") # Expanded
 
-    game.add_army_unit(grande_armee_1st_corps)
-    game.add_army_unit(royal_navy_channel_fleet)
-    game.add_army_unit(austrian_main_army)
+    game.add_army_unit(fra_corps_1)
+    game.add_army_unit(bri_fleet_1)
+    game.add_army_unit(aus_army_1)
+    game.add_army_unit(pru_corps_1) # Expanded
 
-    # 9. Place units in cities (or field positions)
-    game.place_unit_in_city("fra_corps_1", "paris")
-    game.place_unit_in_city("bri_fleet_1", "london") # Fleets might be in ports (cities) or sea zones
-    game.place_unit_in_city("aus_army_1", "vienna")
+    # 9. Place units in cities
+    game.place_unit_in_city("fra_corps_1", "paris") 
+    game.place_unit_in_city("bri_fleet_1", "london") 
+    game.place_unit_in_city("aus_army_1", "vienna") 
+    game.place_unit_in_city("pru_corps_1", "berlin")
+
 
     return game
 
+def game_loop(game_state: GameState):
+    print("\n--- Napoleon Game Prototype Command Mode ---")
+    print("Available commands:")
+    print("  info city <city_id>  - Show details for a city (e.g., info city paris)")
+    print("  summary              - Display current game state summary")
+    print("  next turn            - Advance to the next turn")
+    print("  exit                 - Exit the game")
+
+    while True:
+        command_input = input(f"\nTurn {game_state.current_turn}> ").strip().lower()
+        parts = command_input.split()
+        if not parts:
+            continue
+
+        action = parts[0]
+
+        if action == "exit":
+            print("Exiting game...")
+            break
+        elif action == "summary":
+            game_state.display_summary()
+        elif action == "next" and len(parts) > 1 and parts[1] == "turn":
+            game_state.next_turn()
+            game_state.display_summary() # Display summary after each turn for now
+        elif action == "info" and len(parts) > 2 and parts[1] == "city":
+            city_id_to_info = parts[2]
+            print(game_state.get_city_details_str(city_id_to_info))
+        else:
+            print(f"Unknown command: '{command_input}'. Type 'exit' to quit.")
+
+
 if __name__ == "__main__":
-    print("Setting up Napoleon Game Prototype v0.1...")
+    print("Setting up Napoleon Game Prototype v0.1.1 (with commands)...")
     current_game_state = setup_initial_state()
     print("\n--- Initial Game State Summary ---")
     current_game_state.display_summary()
 
-    # Simulate a few turns
-    current_game_state.next_turn()
-    # Potentially change something, e.g., move a unit, build something (not implemented yet)
-    # france = current_game_state.get_faction("france")
-    # if france:
-    #     france.treasury += 200 # Simple income
-    #     print(f"\nFrance treasury updated to: {france.treasury}")
-
-    current_game_state.display_summary()
-
-    current_game_state.next_turn()
-    current_game_state.display_summary()
+    game_loop(current_game_state)
 
     print("\nPrototype simulation finished.")
 '''


### PR DESCRIPTION
This pull request implements the first player command: `info city <city_id>`.

Key changes:
- Added a basic command input loop to `src/main.py`.
- Implemented `exit`, `summary`, and `next turn` commands.
- Added `get_city_details_str(city_id)` method to `GameState` to retrieve formatted city information.
- Implemented the `info city <city_id>` command in `src/main.py` to display detailed information for a specified city.
- Expanded the initial game setup in `src/main.py` to include Prussia and initial garrisons for better command testing.

This allows the user to interactively query city details during the game simulation.