### PR TITLE
feat: Implement 'move unit' command

### DIFF
--- a/src/game_state.py
+++ b/src/game_state.py
@@ -200,6 +200,30 @@ class GameState:
         
         return "\n".join(details)
 
+    def move_unit(self, unit_id: str, target_city_id: str) -> str:
+        unit = self.army_units.get(unit_id)
+        if not unit:
+            return f"Error: Unit with ID '{unit_id}' not found."
+
+        target_city = self.game_map.get_city(target_city_id)
+        if not target_city:
+            return f"Error: Target city with ID '{target_city_id}' not found."
+
+        # Remove unit from its current city's garrison, if any
+        if unit.current_location_city_id:
+            current_city = self.game_map.get_city(unit.current_location_city_id)
+            if current_city and unit_id in current_city.garrisoned_units:
+                current_city.garrisoned_units.remove(unit_id)
+        
+        # Update unit's location
+        unit.current_location_city_id = target_city_id
+        
+        # Add unit to the target city's garrison
+        if unit_id not in target_city.garrisoned_units:
+            target_city.garrisoned_units.append(unit_id)
+            
+        return f"Unit {unit_id} successfully moved to {target_city.name} (ID: {target_city_id})."
+
     def next_turn(self):
         self.current_turn += 1
         print(f"\n--- Advanced to Turn {self.current_turn} ---")
@@ -212,6 +236,3 @@ class GameState:
                     income += city.economy // 10 # Simple income based on economy
             faction_obj.treasury += income
             print(f"{faction_obj.short_name} received {income} gold. Treasury: {faction_obj.treasury}")
-
-        # Add more turn processing logic here in the future
-        # For example, resource collection, unit movement AI, etc.

--- a/src/main.py
+++ b/src/main.py
@@ -88,12 +88,13 @@ def setup_initial_state() -> GameState:
 def game_loop(game_state: GameState):
     print("\n--- Napoleon Game Prototype Command Mode ---")
     print("Available commands:")
-    print("  info city <city_id>      - Show details for a city (e.g., info city paris)")
-    print("  info general <gen_id>    - Show details for a general (e.g., info general napoleon)")
-    print("  info faction <faction_id> - Show details for a faction (e.g., info faction france)")
-    print("  summary                  - Display current game state summary")
-    print("  next turn                - Advance to the next turn")
-    print("  exit                     - Exit the game")
+    print("  info city <city_id>                - Show details for a city (e.g., info city paris)")
+    print("  info general <gen_id>              - Show details for a general (e.g., info general napoleon)")
+    print("  info faction <faction_id>          - Show details for a faction (e.g., info faction france)")
+    print("  move unit <unit_id> to <city_id>   - Move a unit to another city (e.g., move unit fra_corps_1 to berlin)")
+    print("  summary                          - Display current game state summary")
+    print("  next turn                        - Advance to the next turn")
+    print("  exit                             - Exit the game")
 
     while True:
         command_input = input(f"\nTurn {game_state.current_turn}> ").strip().lower()
@@ -122,12 +123,18 @@ def game_loop(game_state: GameState):
                 print(game_state.get_faction_details_str(target_id))
             else:
                 print(f"Unknown info command: 'info {sub_command}'. Supported: city, general, faction")
+        elif action == "move" and len(parts) == 5 and parts[1] == "unit" and parts[3] == "to":
+            unit_id_to_move = parts[2]
+            target_city_id_for_move = parts[4]
+            print(game_state.move_unit(unit_id_to_move, target_city_id_for_move))
+        elif action == "move" and (len(parts) < 5 or parts[1] != "unit" or parts[3] != "to"):
+             print("Invalid move command. Format: move unit <unit_id> to <target_city_id>")
         else:
-            print(f"Unknown command: '{command_input}'. Type 'exit' to quit.")
+            print(f"Unknown command: '{command_input}'. Type 'help' for a list of commands (not yet implemented, use displayed list).")
 
 
 if __name__ == "__main__":
-    print("Setting up Napoleon Game Prototype v0.1.2 (with more info commands)...")
+    print("Setting up Napoleon Game Prototype v0.1.3 (with move unit command)...")
     current_game_state = setup_initial_state()
     print("\n--- Initial Game State Summary ---")
     current_game_state.display_summary()


### PR DESCRIPTION
This pull request implements the `move unit <unit_id> to <target_city_id>` command.

Key changes:
- Added `move_unit(unit_id, target_city_id)` method to `GameState` (`src/game_state.py`) to handle the logic of moving a unit. This includes:
  - Validating the existence of the unit and target city.
  - Removing the unit from the garrison of the origin city (if any).
  - Updating the unit's `current_location_city_id`.
  - Adding the unit to the garrison of the target city.
  - Returning a success or failure message.
- Updated the command loop in `src/main.py` to parse and process the `move unit` command.
- Added basic argument count validation for the command.
- Updated the command help display in `src/main.py` to include the new command.

This allows players to move units between cities via console commands.