### PR TITLE
feat: Implement 'develop city' command prototype

### DIFF
--- a/src/game_state.py
+++ b/src/game_state.py
@@ -14,6 +14,7 @@ class GameState:
         self.generals: Dict[str, any] = {} # General objects, keyed by general_id
         self.army_units: Dict[str, any] = {} # ArmyUnit objects, keyed by unit_id
         self.player_faction_id: Optional[str] = None
+        self.allowed_building_types = ["market", "barracks"] # Initial list
 
     def add_faction(self, faction_obj):
         self.factions[faction_obj.faction_id] = faction_obj
@@ -224,6 +225,19 @@ class GameState:
             
         return f"Unit {unit_id} successfully moved to {target_city.name} (ID: {target_city_id})."
 
+    def develop_building_in_city(self, city_id: str, building_type: str) -> str:
+        city = self.game_map.get_city(city_id)
+        if not city:
+            return f"Error: City with ID '{city_id}' not found."
+
+        if building_type not in self.allowed_building_types:
+            return f"Error: Building type '{building_type}' is not allowed. Allowed types: {', '.join(self.allowed_building_types)}"
+
+        # In a real implementation, we would add this to a construction queue,
+        # check for resources, development slots, etc.
+        # For now, just acknowledge the command.
+        return f"{city.name} has started development of {building_type}. (Note: This is a prototype, actual construction not yet implemented.)"
+
     def next_turn(self):
         self.current_turn += 1
         print(f"\n--- Advanced to Turn {self.current_turn} ---")
@@ -236,3 +250,4 @@ class GameState:
                     income += city.economy // 10 # Simple income based on economy
             faction_obj.treasury += income
             print(f"{faction_obj.short_name} received {income} gold. Treasury: {faction_obj.treasury}")
+

--- a/src/main.py
+++ b/src/main.py
@@ -92,6 +92,7 @@ def game_loop(game_state: GameState):
     print("  info general <gen_id>              - Show details for a general (e.g., info general napoleon)")
     print("  info faction <faction_id>          - Show details for a faction (e.g., info faction france)")
     print("  move unit <unit_id> to <city_id>   - Move a unit to another city (e.g., move unit fra_corps_1 to berlin)")
+    print("  develop city <id> <building_type>  - Start development in a city (e.g., develop city paris market). Allowed types: market, barracks")
     print("  summary                          - Display current game state summary")
     print("  next turn                        - Advance to the next turn")
     print("  exit                             - Exit the game")
@@ -129,12 +130,18 @@ def game_loop(game_state: GameState):
             print(game_state.move_unit(unit_id_to_move, target_city_id_for_move))
         elif action == "move" and (len(parts) < 5 or parts[1] != "unit" or parts[3] != "to"):
              print("Invalid move command. Format: move unit <unit_id> to <target_city_id>")
+        elif action == "develop" and len(parts) == 4 and parts[1] == "city":
+            city_id_to_develop = parts[2]
+            building_type_to_develop = parts[3]
+            print(game_state.develop_building_in_city(city_id_to_develop, building_type_to_develop))
+        elif action == "develop" and (len(parts) < 4 or parts[1] != "city"):
+            print("Invalid develop command. Format: develop city <city_id> <building_type>")
         else:
             print(f"Unknown command: '{command_input}'. Type 'help' for a list of commands (not yet implemented, use displayed list).")
 
 
 if __name__ == "__main__":
-    print("Setting up Napoleon Game Prototype v0.1.3 (with move unit command)...")
+    print("Setting up Napoleon Game Prototype v0.1.4 (with develop city command prototype)...")
     current_game_state = setup_initial_state()
     print("\n--- Initial Game State Summary ---")
     current_game_state.display_summary()
@@ -142,3 +149,4 @@ if __name__ == "__main__":
     game_loop(current_game_state)
 
     print("\nPrototype simulation finished.")
+


### PR DESCRIPTION
This pull request introduces a prototype for the `develop city <city_id> <building_type>` command.

Key changes:
- Added `develop_building_in_city(city_id, building_type)` method to `GameState` (`src/game_state.py`).
  - This method currently validates the city ID and checks if the `building_type` is one of the allowed types (e.g., `market`, `barracks`).
  - It returns a message indicating the start of development as a placeholder, as actual construction mechanics are not yet implemented.
- Updated the command loop in `src/main.py` to parse and process the `develop city` command.
- Added basic argument count validation for the command.
- Updated the command help display in `src/main.py` to include the new command.

This command serves as a foundational step towards implementing city development and internal affairs mechanics.