### PR TITLE
feat: Implement 'declare war' command

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -5,7 +5,7 @@ from general import General
 from army_unit import ArmyUnit
 from game_map import GameMap
 from game_state import GameState
-from game_enums import UnitType, DiplomaticStatus
+from game_enums import UnitType, DiplomaticStatus 
 
 def setup_initial_state() -> GameState:
     # 1. Create Game Map
@@ -52,10 +52,10 @@ def setup_initial_state() -> GameState:
     # Set Initial Diplomatic Status (after all factions are added)
     game.set_diplomatic_status("france", "britain", DiplomaticStatus.WAR, -100)
     game.set_diplomatic_status("france", "austria", DiplomaticStatus.WAR, -80)
-    game.set_diplomatic_status("france", "prussia", DiplomaticStatus.PEACE, -20) # Initially at peace with Prussia
+    game.set_diplomatic_status("france", "prussia", DiplomaticStatus.PEACE, -20) 
     game.set_diplomatic_status("britain", "austria", DiplomaticStatus.ALLIANCE, 70)
-    game.set_diplomatic_status("britain", "prussia", DiplomaticStatus.PEACE, 30) # Britain might be trying to ally Prussia
-    game.set_diplomatic_status("austria", "prussia", DiplomaticStatus.PEACE, 10) # Austria and Prussia, complex relations
+    game.set_diplomatic_status("britain", "prussia", DiplomaticStatus.PEACE, 30) 
+    game.set_diplomatic_status("austria", "prussia", DiplomaticStatus.PEACE, 10) 
 
     # 5. Assign cities to factions
     game.assign_city_to_faction("paris", "france")
@@ -92,11 +92,10 @@ def setup_initial_state() -> GameState:
     ut_inf_corps = UnitType.INFANTRY_CORPS
     ut_guard_corps = UnitType.GUARD_CORPS
     ut_inf_div = UnitType.INFANTRY_DIVISION
-    # ut_fleet = UnitType.FLEET_CHANNEL # Not used for land movement AI test
+    # ut_fleet = UnitType.FLEET_CHANNEL 
 
     fra_corps_1 = ArmyUnit(unit_id="fra_corps_1", unit_type_id=ut_inf_corps.type_id, base_attack=ut_inf_corps.base_attack, base_defense=ut_inf_corps.base_defense, owning_faction_id="france", soldiers=ut_inf_corps.default_soldiers, leading_general_id="davout")
     fra_guard = ArmyUnit(unit_id="fra_guard", unit_type_id=ut_guard_corps.type_id, base_attack=ut_guard_corps.base_attack, base_defense=ut_guard_corps.base_defense, owning_faction_id="france", soldiers=ut_guard_corps.default_soldiers, leading_general_id="napoleon")
-    # British land unit for AI movement testing
     bri_army_1 = ArmyUnit(unit_id="bri_army_1", unit_type_id=ut_inf_corps.type_id, base_attack=ut_inf_corps.base_attack, base_defense=ut_inf_corps.base_defense, owning_faction_id="britain", soldiers=18000, leading_general_id="nelson") 
     aus_army_1 = ArmyUnit(unit_id="aus_army_1", unit_type_id=ut_inf_div.type_id, base_attack=ut_inf_div.base_attack, base_defense=ut_inf_div.base_defense, owning_faction_id="austria", soldiers=ut_inf_div.default_soldiers, leading_general_id="archduke_charles")
     pru_corps_1 = ArmyUnit(unit_id="pru_corps_1", unit_type_id=ut_inf_corps.type_id, base_attack=ut_inf_corps.base_attack, base_defense=ut_inf_corps.base_defense, owning_faction_id="prussia", soldiers=22000, leading_general_id="blucher")
@@ -123,6 +122,7 @@ def game_loop(game_state: GameState):
     print("  info general <gen_id>              - Show details for a general (e.g., info general napoleon)")
     print("  info faction <faction_id>          - Show details for a faction (e.g., info faction france)")
     print("  info diplomacy [faction_id]        - Show diplomatic relations (e.g., info diplomacy or info diplomacy france)")
+    print("  declare war <target_faction_id>    - Declare war on another faction (e.g., declare war prussia)")
     print("  move unit <unit_id> to <city_id>   - Move YOUR unit to an ADJACENT city (e.g., move unit fra_guard to lyon)")
     print("  develop city <id> <b_type>         - Start development in a city (e.g., develop city paris market). Allowed: market, barracks")
     print("  recruit unit <u_type> in <city_id> [with <gen_id>] - Recruit a new unit in YOUR CAPITAL (e.g., recruit unit infantry_corps in paris with napoleon)")
@@ -187,12 +187,17 @@ def game_loop(game_state: GameState):
             print(game_state.recruit_unit(unit_type_to_recruit, city_id_for_recruit, general_id_for_recruit))
         elif action == "recruit" : 
             print("Invalid recruit command. Format: recruit unit <type> in <city_id> [with <general_id>]")
+        elif action == "declare" and len(parts) == 3 and parts[1] == "war":
+            target_faction_id_for_war = parts[2]
+            print(game_state.declare_war_on_faction(game_state.player_faction_id, target_faction_id_for_war))
+        elif action == "declare" and (len(parts) < 3 or parts[1] != "war"):
+            print("Invalid declare command. Format: declare war <target_faction_id>")
         else:
             print(f"Unknown command: '{command_input}'. Type 'help' for a list of commands (not yet implemented, use displayed list).")
 
 
 if __name__ == "__main__":
-    print("Setting up Napoleon Game Prototype v0.1.12 (AI targeting and improved movement logic)...")
+    print("Setting up Napoleon Game Prototype v0.1.13 (with declare war command)...")
     current_game_state = setup_initial_state()
     print("\n--- Initial Game State Summary ---")
     current_game_state.display_summary()


### PR DESCRIPTION
This pull request introduces a command for the player to declare war on another faction.

Key changes:
- **`GameState.declare_war_on_faction()` Method (`src/game_state.py`):
  - Added a new method `declare_war_on_faction(declaring_faction_id, target_faction_id)`.
  - This method checks if the factions exist, are different, and are not already at war.
  - If valid, it sets the diplomatic status between the two factions to `WAR` and adjusts the relation value (e.g., to -100) using the existing `set_diplomatic_status` method.
  - Returns a success or error message.
- **Command Parser Update (`src/main.py`):
  - The `game_loop` now parses and handles the `declare war <target_faction_id>` command.
  - The player's current faction is used as the `declaring_faction_id`.
- **Help and Version Update (`src/main.py`):
  - Updated command help to include the new `declare war` command.
  - Version string updated to `v0.1.13`.

This allows players to initiate hostilities with other factions, adding a key diplomatic action.